### PR TITLE
Remove apostropes from labels

### DIFF
--- a/kanban-labels.json
+++ b/kanban-labels.json
@@ -23,8 +23,8 @@
   { "name": "Type: Enhancement", "color": "#333333" },
   { "name": "Type: Question", "color": "#333333" },
 
-  { "name": "Don't merge", "color": "#df382c" },
+  { "name": "Dont merge", "color": "#df382c" },
   { "name": "Duplicate", "color": "#c5def5" },
   { "name": "Invalid", "color": "#c5def5" },
-  { "name": "Won't fix", "color": "#c5def5" }
+  { "name": "Wont fix", "color": "#c5def5" }
 ]

--- a/labels.json
+++ b/labels.json
@@ -22,9 +22,9 @@
   { "name": "Type: Enhancement", "color": "#333333" },
   { "name": "Type: Question", "color": "#333333" },
 
-  { "name": "Don't merge", "color": "#df382c" },
+  { "name": "Dont merge", "color": "#df382c" },
   { "name": "Blocked", "color": "#df382c" },
   { "name": "Duplicate", "color": "#c5def5" },
   { "name": "Invalid", "color": "#c5def5" },
-  { "name": "Won't fix", "color": "#c5def5" }
+  { "name": "Wont fix", "color": "#c5def5" }
 ]


### PR DESCRIPTION
## Done
- Removed apostrophes from "Won't fix" and "Don't merge" labels, as they are not being encoded properly upstream with [git-labelmaker](https://github.com/himynameisdave/git-labelmaker)

## QA
- Check code works on local repos (no errant %27s)

## Issues
Fixes #3 