### PR TITLE
Update labels to match practices

### DIFF
--- a/labels.json
+++ b/labels.json
@@ -17,11 +17,9 @@
   { "name": "Review: QA -1", "color": "#df382c" },
   { "name": "Review: UX -1", "color": "#df382c" },
 
-  { "name": "Type: Bug", "color": "#333333" },
-  { "name": "Type: Maintenance", "color": "#333333" },
-  { "name": "Type: Enhancement", "color": "#333333" },
-  { "name": "Type: Question", "color": "#333333" },
-
+  { "name": "Question", "color": "#333333" },
+  { "name": "Good first issue", "color": "#8169CE" },
+  { "name": "Help wanted", "color": "#BEC2F7" },
   { "name": "Dont merge", "color": "#df382c" },
   { "name": "Blocked", "color": "#df382c" },
   { "name": "Duplicate", "color": "#c5def5" },


### PR DESCRIPTION
This integrates suggested changes from
https://github.com/canonical-webteam/practices/pull/62

- Remove "Type: Enhancement", "Type: Bug", "Type: Maintenance"
- Change "Type: Question" to "Question" (as there are no longer any
  other "Type:"s)
- Add "Good first issue" and "Help wanted" to match practices